### PR TITLE
Clean build without Hematonix code

### DIFF
--- a/xdrip/BluetoothPeripheral/Generic/BluetoothPeripheralType.swift
+++ b/xdrip/BluetoothPeripheral/Generic/BluetoothPeripheralType.swift
@@ -49,8 +49,6 @@ enum BluetoothPeripheralType: String, CaseIterable {
     /// Atom
     case AtomType = "Atom"
 
-    /// Hematonix
-    case HematonixType = "Hematonix"
     
     /// to use a Libre (such as L2 US/CA/AUS or Libre 3/Libre 3 Plus) or just any generic heartbeat device as heartbeat
     case Libre3HeartBeatType = "Libre/Generic HeartBeat"
@@ -104,9 +102,6 @@ enum BluetoothPeripheralType: String, CaseIterable {
             
         case .AtomType:
             return AtomBluetoothPeripheralViewModel()
-
-        case .HematonixType:
-            return nil
             
         case .Libre3HeartBeatType:
             return Libre3HeartBeatBluetoothPeripheralViewModel()
@@ -170,9 +165,6 @@ enum BluetoothPeripheralType: String, CaseIterable {
             
         case .AtomType:
             return Atom(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
-
-        case .HematonixType:
-            return Hematonix(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
             
         case .Libre3HeartBeatType:
             return Libre2HeartBeat(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
@@ -198,7 +190,7 @@ enum BluetoothPeripheralType: String, CaseIterable {
         case .M5StackType, .M5StickCType:
             return .M5Stack
             
-        case .DexcomType, .BubbleType, .MiaoMiaoType, .BluconType, .GNSentryType, .BlueReaderType, .DropletType, .DexcomG4Type, .WatlaaType, .Libre2Type, .AtomType, .HematonixType, .DexcomG7Type:
+        case .DexcomType, .BubbleType, .MiaoMiaoType, .BluconType, .GNSentryType, .BlueReaderType, .DropletType, .DexcomG4Type, .WatlaaType, .Libre2Type, .AtomType, .DexcomG7Type:
             return .CGM
             
         case .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType:
@@ -275,7 +267,7 @@ enum BluetoothPeripheralType: String, CaseIterable {
         
         switch self {
             
-        case .BubbleType, .MiaoMiaoType, .AtomType, .HematonixType: //, .DexcomType:
+        case .BubbleType, .MiaoMiaoType, .AtomType: //, .DexcomType:
             return true
             
         case .Libre2Type:
@@ -294,7 +286,7 @@ enum BluetoothPeripheralType: String, CaseIterable {
         
         switch self {
             
-        case .Libre2Type, .BubbleType, .MiaoMiaoType, .WatlaaType, .BluconType, .BlueReaderType, .DropletType , .GNSentryType, .AtomType, .HematonixType:
+        case .Libre2Type, .BubbleType, .MiaoMiaoType, .WatlaaType, .BluconType, .BlueReaderType, .DropletType , .GNSentryType, .AtomType:
             return true
             
         default:

--- a/xdrip/Core Data/classes/BLEPeripheral+CoreDataProperties.swift
+++ b/xdrip/Core Data/classes/BLEPeripheral+CoreDataProperties.swift
@@ -69,9 +69,6 @@ extension BLEPeripheral {
     @NSManaged public var atom: Atom?
 
     // a BLEPeripheral should only have one of dexcomG5, watlaa, m5Stack, ...
-    @NSManaged public var hematonix: Hematonix?
-    
-    // a BLEPeripheral should only have one of dexcomG5, watlaa, m5Stack, ...
     @NSManaged public var libre2heartbeat: Libre2HeartBeat?
     
     // a BLEPeripheral should only have one of dexcomG5, watlaa, m5Stack, ...

--- a/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
+++ b/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
@@ -496,10 +496,6 @@ class BluetoothPeripheralManager: NSObject {
                     return .AtomType
                 }
 
-            case .HematonixType:
-                if bluetoothTransmitter is CGMHematonixTransmitter {
-                    return .HematonixType
-                }
                 
             case .BluconType:
                 if bluetoothTransmitter is CGMBluconTransmitter {
@@ -606,9 +602,6 @@ class BluetoothPeripheralManager: NSObject {
             }
             
             return CGMAtomTransmitter(address: nil, name: nil, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate ?? self, cGMAtomTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, sensorSerialNumber: nil, webOOPEnabled: nil, nonFixedSlopeEnabled: nil, firmWare: nil)
-
-        case .HematonixType:
-            return CGMHematonixTransmitter(bluetoothTransmitterDelegate: bluetoothTransmitterDelegate ?? self)
 
         case .DropletType:
             

--- a/xdrip/Utilities/Trace.swift
+++ b/xdrip/Utilities/Trace.swift
@@ -639,14 +639,6 @@ class Trace {
 
                         }
 
-                    case .HematonixType:
-                        if let hematonix = blePeripheral.hematonix {
-
-                            traceInfo.appendStringAndNewLine("        Type: " + bluetoothPeripheralType.rawValue)
-                            traceInfo.appendStringAndNewLine("        Battery level: " + hematonix.batteryLevel.description)
-
-                        }
-                        
                     case .WatlaaType:
                         if let watlaa = blePeripheral.watlaa {
                             


### PR DESCRIPTION
## Summary
- remove `hematonix` property from BLEPeripheral model
- drop Hematonix-specific cases from BluetoothPeripheralType
- eliminate Hematonix handling from trace diagnostics and manager

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_685011ab586c8332bedade376649a497