### PR TITLE
Fix exhaustive switch in Trace

### DIFF
--- a/xdrip/Utilities/Trace.swift
+++ b/xdrip/Utilities/Trace.swift
@@ -639,6 +639,10 @@ class Trace {
 
                         }
 
+                    case .HematonixType:
+
+                        traceInfo.appendStringAndNewLine("        Type: " + bluetoothPeripheralType.rawValue)
+
                     case .WatlaaType:
                         if let watlaa = blePeripheral.watlaa {
                             


### PR DESCRIPTION
## Summary
- add missing Hematonix case in the bluetooth peripheral switch

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68504a638d248332b928693763750a00