### PR TITLE
Add Hematonix support

### DIFF
--- a/xdrip/BluetoothPeripheral/CGM/Hematonix/Hematonix+BluetoothPeripheral.swift
+++ b/xdrip/BluetoothPeripheral/CGM/Hematonix/Hematonix+BluetoothPeripheral.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension Hematonix: BluetoothPeripheral {
+    func bluetoothPeripheralType() -> BluetoothPeripheralType {
+        return .HematonixType
+    }
+}

--- a/xdrip/BluetoothPeripheral/Generic/BluetoothPeripheralType.swift
+++ b/xdrip/BluetoothPeripheral/Generic/BluetoothPeripheralType.swift
@@ -48,6 +48,7 @@ enum BluetoothPeripheralType: String, CaseIterable {
     
     /// Atom
     case AtomType = "Atom"
+    case HematonixType = "Hematonix"
     
     /// to use a Libre (such as L2 US/CA/AUS or Libre 3/Libre 3 Plus) or just any generic heartbeat device as heartbeat
     case Libre3HeartBeatType = "Libre/Generic HeartBeat"
@@ -101,6 +102,9 @@ enum BluetoothPeripheralType: String, CaseIterable {
             
         case .AtomType:
             return AtomBluetoothPeripheralViewModel()
+
+        case .HematonixType:
+            return nil
             
         case .Libre3HeartBeatType:
             return Libre3HeartBeatBluetoothPeripheralViewModel()
@@ -164,6 +168,9 @@ enum BluetoothPeripheralType: String, CaseIterable {
             
         case .AtomType:
             return Atom(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
+
+        case .HematonixType:
+            return Hematonix(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
             
         case .Libre3HeartBeatType:
             return Libre2HeartBeat(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
@@ -189,7 +196,7 @@ enum BluetoothPeripheralType: String, CaseIterable {
         case .M5StackType, .M5StickCType:
             return .M5Stack
             
-        case .DexcomType, .BubbleType, .MiaoMiaoType, .BluconType, .GNSentryType, .BlueReaderType, .DropletType, .DexcomG4Type, .WatlaaType, .Libre2Type, .AtomType, .DexcomG7Type:
+        case .DexcomType, .BubbleType, .MiaoMiaoType, .BluconType, .GNSentryType, .BlueReaderType, .DropletType, .DexcomG4Type, .WatlaaType, .Libre2Type, .AtomType, .HematonixType, .DexcomG7Type:
             return .CGM
             
         case .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType:
@@ -266,7 +273,7 @@ enum BluetoothPeripheralType: String, CaseIterable {
         
         switch self {
             
-        case .BubbleType, .MiaoMiaoType, .AtomType: //, .DexcomType:
+        case .BubbleType, .MiaoMiaoType, .AtomType, .HematonixType: //, .DexcomType:
             return true
             
         case .Libre2Type:
@@ -285,7 +292,7 @@ enum BluetoothPeripheralType: String, CaseIterable {
         
         switch self {
             
-        case .Libre2Type, .BubbleType, .MiaoMiaoType, .WatlaaType, .BluconType, .BlueReaderType, .DropletType , .GNSentryType, .AtomType:
+        case .Libre2Type, .BubbleType, .MiaoMiaoType, .WatlaaType, .BluconType, .BlueReaderType, .DropletType , .GNSentryType, .AtomType, .HematonixType:
             return true
             
         default:

--- a/xdrip/BluetoothTransmitter/CGM/Generic/CGMTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Generic/CGMTransmitter.swift
@@ -111,6 +111,7 @@ enum CGMTransmitterType:String, CaseIterable {
     
     /// Atom
     case Atom = "Atom"
+    case Hematonix = "Hematonix"
     
     /// watlaa
     case watlaa = "Watlaa"
@@ -126,7 +127,7 @@ enum CGMTransmitterType:String, CaseIterable {
         case .dexcomG4, .dexcom, .dexcomG7:
             return .Dexcom
             
-        case .miaomiao, .Bubble, .GNSentry, .Droplet1, .blueReader, .watlaa, .Blucon, .Libre2, .Atom:
+        case .miaomiao, .Bubble, .GNSentry, .Droplet1, .blueReader, .watlaa, .Blucon, .Libre2, .Atom, .Hematonix:
             return .Libre
             
         }
@@ -150,13 +151,13 @@ enum CGMTransmitterType:String, CaseIterable {
             // the others will not send sensorStart and will also not send sensorAge
             return true
             
-        case .miaomiao, .Bubble:
+        case .miaomiao, .Bubble, .Hematonix:
             return true
             
         case .GNSentry:
             return false
             
-        case .Blucon:
+        case .Blucon, .Hematonix:
             return true
             
         case .Droplet1:
@@ -171,7 +172,7 @@ enum CGMTransmitterType:String, CaseIterable {
         case .Libre2:
             return true
             
-        case .Atom:
+        case .Atom, .Hematonix:
             return true
             
         case .dexcomG7:
@@ -233,8 +234,12 @@ enum CGMTransmitterType:String, CaseIterable {
         case .Libre2:
             return ConstantsDefaultAlertLevels.defaultBatteryAlertLevelLibre2
             
+
         case .Atom:
             return ConstantsDefaultAlertLevels.defaultBatteryAlertLevelAtom
+
+        case .Hematonix:
+            return ConstantsDefaultAlertLevels.defaultBatteryAlertLevelMiaoMiao
             
         case .dexcomG7:
             // we don't use this
@@ -270,17 +275,20 @@ enum CGMTransmitterType:String, CaseIterable {
             
         case .watlaa:
             return "%"
-            
+
         case .Libre2:
             return "%"
-            
+
         case .Atom:
             return "%"
-            
+
+        case .Hematonix:
+            return "%"
+
         case .dexcomG7:
             // we don't use this
             return ""
-            
+
         }
     }
     

--- a/xdrip/BluetoothTransmitter/CGM/Hematonix/CGMHematonixTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Hematonix/CGMHematonixTransmitter.swift
@@ -1,0 +1,60 @@
+import Foundation
+import CoreBluetooth
+import os
+
+class CGMHematonixTransmitter: BluetoothTransmitter, CGMTransmitter {
+
+    private let companyID: UInt16 = 0x0006
+    private let svcUUID = CBUUID(string: "FD5A")
+    private let sensorUID: String?
+    private let log = OSLog(subsystem: ConstantsLog.subSystem, category: "CGMHematonix")
+    private weak var cgmTransmitterDelegate: CGMTransmitterDelegate?
+
+    init(address: String?, name: String?, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate, cGMTransmitterDelegate: CGMTransmitterDelegate, sensorUID: String?) {
+        self.sensorUID = sensorUID?.uppercased()
+        self.cgmTransmitterDelegate = cGMTransmitterDelegate
+        super.init(addressAndName: .notYetConnected(expectedName: "Hematonix"), CBUUID_Advertisement: nil, servicesCBUUIDs: nil, CBUUID_ReceiveCharacteristic: "0000", CBUUID_WriteCharacteristic: "0000", bluetoothTransmitterDelegate: bluetoothTransmitterDelegate)
+    }
+
+    override func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        if central.state == .poweredOn {
+            central.scanForPeripherals(withServices: nil, options: [.allowDuplicates: true])
+            trace("CGMHematonix ▶︎ scanning BLE", log: log, category: "CGMHematonix", type: .info)
+        }
+    }
+
+    override func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String : Any], rssi RSSI: NSNumber) {
+        if let msd = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data,
+           msd.count >= 4,
+           msd.toUInt16(0) == companyID,
+           let mmol = HematonixDecoder.decode(msd.dropFirst(2)) {
+            push(mmol, from: peripheral)
+            return
+        }
+
+        if let svc = advertisementData[CBAdvertisementDataServiceDataKey] as? [CBUUID: Data],
+           let blob = svc[svcUUID],
+           let mmol = HematonixDecoder.decode(blob) {
+            push(mmol, from: peripheral)
+            return
+        }
+
+        if let ext = advertisementData["kCBAdvDataExtendedData"] as? Data,
+           let mmol = HematonixDecoder.decodeExtended(ext) {
+            push(mmol, from: peripheral)
+        }
+    }
+
+    private func push(_ mmol: Double, from peripheral: CBPeripheral) {
+        if let uid = sensorUID, !peripheral.identifier.uuidString.hasSuffix(uid) {
+            return
+        }
+        var data = [GlucoseData(timeStamp: Date(), glucoseLevelRaw: mmol)]
+        cgmTransmitterDelegate?.cgmTransmitterInfoReceived(glucoseData: &data, transmitterBatteryInfo: nil, sensorAge: nil)
+    }
+
+    // MARK: CGMTransmitter
+    func cgmTransmitterType() -> CGMTransmitterType { return .Hematonix }
+    func getCBUUID_Service() -> String { "" }
+    func getCBUUID_Receive() -> String { "" }
+}

--- a/xdrip/Constants/ConstantsLog.swift
+++ b/xdrip/Constants/ConstantsLog.swift
@@ -120,6 +120,9 @@ enum ConstantsLog {
     
     /// atom
     static let categoryCGMAtom =                        "categoryCGMAtom               "
+
+    /// Hematonix
+    static let categoryCGMHematonix =                   "CGMHematonix                "
     
     /// LibreOOPClient
     static let categoryLibreOOPClient =                 "LibreOOPClient                "

--- a/xdrip/Core Data/classes/BLEPeripheral+CoreDataProperties.swift
+++ b/xdrip/Core Data/classes/BLEPeripheral+CoreDataProperties.swift
@@ -67,6 +67,8 @@ extension BLEPeripheral {
     
     // a BLEPeripheral should only have one of dexcomG5, watlaa, m5Stack, ...
     @NSManaged public var atom: Atom?
+
+    @NSManaged public var hematonix: Hematonix?
     
     // a BLEPeripheral should only have one of dexcomG5, watlaa, m5Stack, ...
     @NSManaged public var libre2heartbeat: Libre2HeartBeat?

--- a/xdrip/Core Data/classes/Hematonix+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/Hematonix+CoreDataClass.swift
@@ -1,0 +1,18 @@
+import Foundation
+import CoreData
+
+public class Hematonix: NSManagedObject {
+
+    public var batteryLevel: Int = 0
+    public var sensorState: LibreSensorState = .unknown
+
+    init(address: String, name: String, alias: String?, nsManagedObjectContext:NSManagedObjectContext) {
+        let entity = NSEntityDescription.entity(forEntityName: "Hematonix", in: nsManagedObjectContext)!
+        super.init(entity: entity, insertInto: nsManagedObjectContext)
+        blePeripheral = BLEPeripheral(address: address, name: name, alias: nil, bluetoothPeripheralType: .HematonixType, nsManagedObjectContext: nsManagedObjectContext)
+    }
+
+    private override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
+        super.init(entity: entity, insertInto: context)
+    }
+}

--- a/xdrip/Core Data/classes/Hematonix+CoreDataProperties.swift
+++ b/xdrip/Core Data/classes/Hematonix+CoreDataProperties.swift
@@ -1,0 +1,13 @@
+import Foundation
+import CoreData
+
+extension Hematonix {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Hematonix> {
+        return NSFetchRequest<Hematonix>(entityName: "Hematonix")
+    }
+
+    @NSManaged public var blePeripheral: BLEPeripheral
+    @NSManaged public var firmware: String?
+    @NSManaged public var hardware: String?
+}

--- a/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
+++ b/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
@@ -167,7 +167,7 @@ class BluetoothPeripheralManager: NSObject {
                     // no need to send reading to watlaa in master mode
                     break
                     
-                case .DexcomType, .BubbleType, .MiaoMiaoType, .BluconType, .GNSentryType, .BlueReaderType, .DropletType, .DexcomG4Type, .Libre2Type, .AtomType, .DexcomG7Type:
+                case .DexcomType, .BubbleType, .MiaoMiaoType, .BluconType, .GNSentryType, .BlueReaderType, .DropletType, .DexcomG4Type, .Libre2Type, .AtomType, .HematonixType, .DexcomG7Type:
                     // cgm's don't receive reading, they send it
                     break
                     
@@ -495,6 +495,11 @@ class BluetoothPeripheralManager: NSObject {
                 if bluetoothTransmitter is CGMAtomTransmitter {
                     return .AtomType
                 }
+
+            case .HematonixType:
+                if bluetoothTransmitter is CGMHematonixTransmitter {
+                    return .HematonixType
+                }
                 
             case .BluconType:
                 if bluetoothTransmitter is CGMBluconTransmitter {
@@ -601,6 +606,14 @@ class BluetoothPeripheralManager: NSObject {
             }
             
             return CGMAtomTransmitter(address: nil, name: nil, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate ?? self, cGMAtomTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, sensorSerialNumber: nil, webOOPEnabled: nil, nonFixedSlopeEnabled: nil, firmWare: nil)
+
+        case .HematonixType:
+
+            guard let cgmTransmitterDelegate = cgmTransmitterDelegate else {
+                fatalError("in createNewTransmitter, HematonixType, cgmTransmitterDelegate is nil")
+            }
+
+            return CGMHematonixTransmitter(address: nil, name: nil, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate ?? self, cGMTransmitterDelegate: cgmTransmitterDelegate, sensorUID: nil)
             
         case .DropletType:
             
@@ -856,9 +869,28 @@ class BluetoothPeripheralManager: NSObject {
                         } else {
                             
                             // bluetoothTransmitters array (which shoul dhave the same number of elements as bluetoothPeripherals) needs to have an empty row for the transmitter
+                        bluetoothTransmitters.insert(nil, at: index)
+
+                    }
+
+                case .HematonixType:
+
+                    if let hematonix = blePeripheral.hematonix {
+
+                        blePeripheralFound = true
+
+                        let index = insertInBluetoothPeripherals(bluetoothPeripheral: hematonix)
+
+                        if hematonix.blePeripheral.shouldconnect {
+                            bluetoothTransmitters.insert(CGMHematonixTransmitter(address: hematonix.blePeripheral.address, name: hematonix.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, sensorUID: nil), at: index)
+                            if bluetoothPeripheralType.category() == .CGM {
+                                currentCgmTransmitterAddress = blePeripheral.address
+                            }
+                        } else {
                             bluetoothTransmitters.insert(nil, at: index)
-                            
                         }
+
+                    }
                         
                     }
                     
@@ -1449,7 +1481,7 @@ class BluetoothPeripheralManager: NSObject {
                     bluetoothPeripheral.blePeripheral.parameterUpdateNeededAtNextConnect = true
                 }
              
-            case .WatlaaType, .DexcomType, .BubbleType, .MiaoMiaoType, .BluconType, .GNSentryType, .BlueReaderType, .DropletType, .DexcomG4Type, .Libre2Type, .AtomType, .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType, .DexcomG7Type:
+            case .WatlaaType, .DexcomType, .BubbleType, .MiaoMiaoType, .BluconType, .GNSentryType, .BlueReaderType, .DropletType, .DexcomG4Type, .Libre2Type, .AtomType, .HematonixType, .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType, .DexcomG7Type:
                 
                 // nothing to check
                 break

--- a/xdrip/Utilities/Trace.swift
+++ b/xdrip/Utilities/Trace.swift
@@ -633,10 +633,18 @@ class Trace {
                         
                     case .AtomType:
                         if let miaoMiao = blePeripheral.atom {
-                            
+
                             traceInfo.appendStringAndNewLine("        Type: " + bluetoothPeripheralType.rawValue)
                             traceInfo.appendStringAndNewLine("        Battery level: " + miaoMiao.batteryLevel.description)
-                            
+
+                        }
+
+                    case .HematonixType:
+                        if let hemi = blePeripheral.hematonix {
+
+                            traceInfo.appendStringAndNewLine("        Type: " + bluetoothPeripheralType.rawValue)
+                            traceInfo.appendStringAndNewLine("        Battery level: " + hemi.batteryLevel.description)
+
                         }
                         
                     case .WatlaaType:

--- a/xdrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xdrip/View Controllers/Root View Controller/RootViewController.swift
@@ -2106,7 +2106,7 @@ final class RootViewController: UIViewController, ObservableObject {
             calibrator = NoCalibrator()
             
             
-        case .miaomiao, .GNSentry, .Blucon, .Bubble, .Droplet1, .blueReader, .watlaa, .Libre2, .Atom:
+        case .miaomiao, .GNSentry, .Blucon, .Bubble, .Droplet1, .blueReader, .watlaa, .Libre2, .Atom, .Hematonix:
             
             if cgmTransmitter.isWebOOPEnabled() {
                 


### PR DESCRIPTION
## Summary
- add Hematonix cases for CGM transmitter and Bluetooth peripheral enums
- provide a stub CGMHematonixTransmitter and related CoreData model
- hook new transmitter type into BluetoothPeripheralManager
- expose Hematonix device type to UI and logging

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68504f61ce28833282dee344c4f1e6aa