### PR TITLE
Fix Hematonix decoder integration

### DIFF
--- a/xdrip/BluetoothTransmitter/CGM/Hematonix/HematonixDecoder.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Hematonix/HematonixDecoder.swift
@@ -3,11 +3,26 @@ enum HematonixDecoder {
     private static let k = 0.00056
     private static let b = 15.4 - 0.00056 * 265.0
 
+    /// Декодируем Manufacturer / Service‑Data payload
     static func decode(_ payload: Data) -> Double? {
         guard payload.count >= 2 else { return nil }
-        let raw = payload.toU16(0)
+        let raw = payload.toUInt16(0)
         let mmol = Double(raw) * k + b
         // sanity-check
-        return (2...25).contains(mmol) ? round(mmol * 10)/10 : nil
+        return (2...25).contains(mmol) ? round(mmol * 10) / 10 : nil
+    }
+
+    /// Декодируем «длинный» блок 0xE4 (ADV_EXT_IND)
+    static func decodeExtended(_ blob: Data) -> Double? {
+        guard blob.count >= 0x20 else { return nil }
+        let raw = blob[0x11]
+        let mmol = Double(raw) / 10.0
+        return (2...25).contains(mmol) ? mmol : nil
+    }
+}
+
+extension Data {
+    func toUInt16(_ offset: Int) -> UInt16 {
+        UInt16(littleEndian: self[offset..<offset + 2].withUnsafeBytes { $0.load(as: UInt16.self) })
     }
 }

--- a/xdrip/BluetoothTransmitter/CGM/Hematonix/HematonixManager.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Hematonix/HematonixManager.swift
@@ -95,31 +95,3 @@ final class HematonixManager: NSObject, CBCentralManagerDelegate {
     }
 }
 
-// MARK: – Decoder stub
-///  *Временный* декодер: берёт один байт → делит на 10.
-///  При смене прошивки Hematonix достаточно поправить offset или формулу.
-enum HematonixDecoder {
-
-    /// Декодируем Manufacturer / Service‑Data payload
-    static func decode(_ data: Data) -> Double? {
-        guard data.count >= 1 else { return nil }
-        let raw = data[0]                  // первый байт after company / UUID
-        let mmol = Double(raw) / 10.0
-        return (2...25).contains(mmol) ? mmol : nil
-    }
-
-    /// Декодируем «длинный» блок 0xE4 (ADV_EXT_IND)
-    static func decodeExtended(_ blob: Data) -> Double? {
-        // sanity: длина 0x74 & offset 0x11 держатся на прошивке v110
-        guard blob.count >= 0x20 else { return nil }
-        let raw = blob[0x11]
-        return Double(raw) / 10.0
-    }
-}
-
-// MARK: – Helper
-private extension Data {
-    func toUInt16(_ offset: Int) -> UInt16 {
-        UInt16(littleEndian: self[offset..<offset+2].withUnsafeBytes { $0.load(as: UInt16.self) })
-    }
-}


### PR DESCRIPTION
## Summary
- consolidate Hematonix decoding logic
- remove duplicate decoder stub from manager
- provide `decodeExtended` and helper utilities in `HematonixDecoder`

## Testing
- `swiftc -parse xdrip/BluetoothTransmitter/CGM/Hematonix/HematonixManager.swift`
- `swiftc -parse xdrip/BluetoothTransmitter/CGM/Hematonix/HematonixDecoder.swift`
- `swiftc -emit-module xdrip/BluetoothTransmitter/CGM/Hematonix/HematonixManager.swift xdrip/BluetoothTransmitter/CGM/Hematonix/HematonixDecoder.swift` *(fails: no such module 'CoreBluetooth')*

------
https://chatgpt.com/codex/tasks/task_e_6850e4d2dfd08332bd92cec09f7d8bd0