### PR TITLE
Add Hematonix CGM device

### DIFF
--- a/xdrip/BluetoothPeripheral/CGM/Hematonix/Hematonix+BluetoothPeripheral.swift
+++ b/xdrip/BluetoothPeripheral/CGM/Hematonix/Hematonix+BluetoothPeripheral.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension Hematonix: BluetoothPeripheral {
+    func bluetoothPeripheralType() -> BluetoothPeripheralType {
+        return .HematonixType
+    }
+}

--- a/xdrip/BluetoothPeripheral/Generic/BluetoothPeripheralType.swift
+++ b/xdrip/BluetoothPeripheral/Generic/BluetoothPeripheralType.swift
@@ -42,6 +42,9 @@ enum BluetoothPeripheralType: String, CaseIterable {
     
     /// GNSentry
     case GNSentryType = "GNSentry"
+
+    /// Hematonix CGM
+    case HematonixType = "Hematonix CGM"
     
     /// watlaa master
     case WatlaaType = "Watlaa"
@@ -86,7 +89,10 @@ enum BluetoothPeripheralType: String, CaseIterable {
             
         case .GNSentryType:
             return GNSEntryBluetoothPeripheralViewModel()
-            
+
+        case .HematonixType:
+            return nil
+
         case .BlueReaderType:
             return nil
             
@@ -149,7 +155,10 @@ enum BluetoothPeripheralType: String, CaseIterable {
             
         case .GNSentryType:
             return GNSEntry(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
-            
+
+        case .HematonixType:
+            return Hematonix(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
+
         case .BlueReaderType:
             return BlueReader(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
             
@@ -189,7 +198,7 @@ enum BluetoothPeripheralType: String, CaseIterable {
         case .M5StackType, .M5StickCType:
             return .M5Stack
             
-        case .DexcomType, .BubbleType, .MiaoMiaoType, .BluconType, .GNSentryType, .BlueReaderType, .DropletType, .DexcomG4Type, .WatlaaType, .Libre2Type, .AtomType, .DexcomG7Type:
+        case .DexcomType, .BubbleType, .MiaoMiaoType, .BluconType, .GNSentryType, .HematonixType, .BlueReaderType, .DropletType, .DexcomG4Type, .WatlaaType, .Libre2Type, .AtomType, .DexcomG7Type:
             return .CGM
             
         case .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType:

--- a/xdrip/Core Data/classes/BLEPeripheral+CoreDataProperties.swift
+++ b/xdrip/Core Data/classes/BLEPeripheral+CoreDataProperties.swift
@@ -49,6 +49,9 @@ extension BLEPeripheral {
     
     /// a BLEPeripheral should only have one of dexcomG5, watlaa, m5Stack, ...
     @NSManaged public var gNSEntry: GNSEntry?
+
+    /// a BLEPeripheral should only have one of dexcomG5, watlaa, m5Stack, ...
+    @NSManaged public var hematonix: Hematonix?
     
     /// a BLEPeripheral should only have one of dexcomG5, watlaa, m5Stack, ...
     @NSManaged public var blueReader: BlueReader?

--- a/xdrip/Core Data/classes/Hematonix+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/Hematonix+CoreDataClass.swift
@@ -1,0 +1,21 @@
+import Foundation
+import CoreData
+
+public class Hematonix: NSManagedObject {
+
+    /// create Hematonix
+    /// - parameters:
+    init(address: String, name: String, alias: String?, nsManagedObjectContext: NSManagedObjectContext) {
+
+        let entity = NSEntityDescription.entity(forEntityName: "Hematonix", in: nsManagedObjectContext)!
+
+        super.init(entity: entity, insertInto: nsManagedObjectContext)
+
+        blePeripheral = BLEPeripheral(address: address, name: name, alias: alias, bluetoothPeripheralType: .HematonixType, nsManagedObjectContext: nsManagedObjectContext)
+    }
+
+    private override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
+        super.init(entity: entity, insertInto: context)
+    }
+
+}

--- a/xdrip/Core Data/classes/Hematonix+CoreDataProperties.swift
+++ b/xdrip/Core Data/classes/Hematonix+CoreDataProperties.swift
@@ -1,0 +1,13 @@
+import Foundation
+import CoreData
+
+extension Hematonix {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Hematonix> {
+        return NSFetchRequest<Hematonix>(entityName: "Hematonix")
+    }
+
+    // blePeripheral is required to conform to protocol BluetoothPeripheral
+    @NSManaged public var blePeripheral: BLEPeripheral
+
+}

--- a/xdrip/Core Data/xdrip.xcdatamodeld/xdrip v16.xcdatamodel/contents
+++ b/xdrip/Core Data/xdrip.xcdatamodeld/xdrip v16.xcdatamodel/contents
@@ -55,6 +55,7 @@
         <relationship name="blucon" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Blucon" inverseName="blePeripheral" inverseEntity="Blucon"/>
         <relationship name="blueReader" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BlueReader" inverseName="blePeripheral" inverseEntity="BlueReader"/>
         <relationship name="bubble" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Bubble" inverseName="blePeripheral" inverseEntity="Bubble"/>
+        <relationship name="hematonix" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Hematonix" inverseName="blePeripheral" inverseEntity="Hematonix"/>
         <relationship name="dexcomG4" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="DexcomG4" inverseName="blePeripheral" inverseEntity="DexcomG4"/>
         <relationship name="dexcomG5" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="DexcomG5" inverseName="blePeripheral" inverseEntity="DexcomG5"/>
         <relationship name="dexcomG7" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DexcomG7" inverseName="blePeripheral" inverseEntity="DexcomG7"/>
@@ -73,6 +74,9 @@
     </entity>
     <entity name="BlueReader" representedClassName=".BlueReader" syncable="YES">
         <relationship name="blePeripheral" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BLEPeripheral" inverseName="blueReader" inverseEntity="BLEPeripheral"/>
+    </entity>
+    <entity name="Hematonix" representedClassName=".Hematonix" syncable="YES">
+        <relationship name="blePeripheral" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BLEPeripheral" inverseName="hematonix" inverseEntity="BLEPeripheral"/>
     </entity>
     <entity name="Bubble" representedClassName=".Bubble" syncable="YES">
         <attribute name="firmware" optional="YES" attributeType="String"/>

--- a/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
+++ b/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
@@ -167,7 +167,7 @@ class BluetoothPeripheralManager: NSObject {
                     // no need to send reading to watlaa in master mode
                     break
                     
-                case .DexcomType, .BubbleType, .MiaoMiaoType, .BluconType, .GNSentryType, .BlueReaderType, .DropletType, .DexcomG4Type, .Libre2Type, .AtomType, .DexcomG7Type:
+                case .DexcomType, .BubbleType, .MiaoMiaoType, .BluconType, .GNSentryType, .HematonixType, .BlueReaderType, .DropletType, .DexcomG4Type, .Libre2Type, .AtomType, .DexcomG7Type:
                     // cgm's don't receive reading, they send it
                     break
                     

--- a/xdrip/Utilities/Trace.swift
+++ b/xdrip/Utilities/Trace.swift
@@ -617,10 +617,17 @@ class Trace {
 
                     case .GNSentryType:
                         if let gNSEntry = blePeripheral.gNSEntry {
-                            
+
                             traceInfo.appendStringAndNewLine("        Type: " + bluetoothPeripheralType.rawValue)
                             traceInfo.appendStringAndNewLine("        Battery level: " + gNSEntry.batteryLevel.description)
-                            
+
+                        }
+
+                    case .HematonixType:
+                        if blePeripheral.hematonix != nil {
+
+                            traceInfo.appendStringAndNewLine("        Type: " + bluetoothPeripheralType.rawValue)
+
                         }
 
                     case .MiaoMiaoType:


### PR DESCRIPTION
## Summary
- add `HematonixType` to `BluetoothPeripheralType`
- support Hematonix in peripheral creation and categorization
- integrate Hematonix in background manager logic
- create Core Data model and wrapper for Hematonix

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851201e57a883329cbadcc10c6ad658